### PR TITLE
Fix pinned mod versions being ignored depending on discovery order

### DIFF
--- a/Yafc.Parser.Tests/ModSelectionTests.cs
+++ b/Yafc.Parser.Tests/ModSelectionTests.cs
@@ -1,0 +1,42 @@
+﻿using System.IO.Compression;
+using System.Text;
+using static Yafc.Parser.FactorioDataSource;
+
+namespace Yafc.Parser.Tests;
+
+public class ModSelectionTests {
+    [Theory]
+    [InlineData("2.1.1", "2.0.5", "2.0.5")]
+    [InlineData("2.0.5", "2.1.1", "2.0.5")]
+    [InlineData("2.1.1", "2.0.5", null)]
+    [InlineData("2.0.5", "2.1.1", null)]
+    [InlineData("2.1.1", "2.0.5", "1.0.0")]
+    public void SelectsRequestedVersionRegardlessOfDiscoveryOrder(string first, string second, string? requested) {
+        using ModInfo firstMod = CreateMod(first);
+        using ModInfo secondMod = CreateMod(second);
+        Version? requestedVersion = requested == null ? null : new(requested);
+        ModInfo? selected = null;
+        foreach (ModInfo candidate in new[] { firstMod, secondMod }) {
+            if (ShouldReplaceMod(selected, candidate, requestedVersion)) {
+                selected = candidate;
+            }
+        }
+        Assert.Equal(requested == "2.0.5" ? "2.0.5" : "2.1.1", selected?.version);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PrefersFolderForSameRequestedVersion(bool archiveFirst) {
+        using var archive = new ZipArchive(new MemoryStream(), ZipArchiveMode.Create);
+        using ModInfo zipped = CreateMod("2.0.5", archive);
+        using ModInfo folder = CreateMod("2.0.5");
+        ModInfo first = archiveFirst ? zipped : folder;
+        ModInfo second = archiveFirst ? folder : zipped;
+        ModInfo selected = ShouldReplaceMod(first, second, new Version("2.0.5")) ? second : first;
+        Assert.Same(folder, selected);
+    }
+
+    private static ModInfo CreateMod(string version, ZipArchive? archive = null) =>
+        new("test-mod/", Encoding.UTF8.GetBytes($$"""{"name":"test-mod","version":"{{version}}","factorio_version":"2.0"}"""), 0, 0, archive);
+}

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -309,10 +309,9 @@ public static partial class FactorioDataSource {
 
                 ModInfo? existing = null;
                 bool modFound = mod.ValidForFactorioVersion(factorioVersion) && allMods.TryGetValue(mod.name, out existing);
-                bool higherVersionOrFolder = existing == null || mod.parsedVersion > existing.parsedVersion || (mod.parsedVersion == existing.parsedVersion && existing.zipArchive != null && mod.zipArchive == null);
-                bool existingMatchesVersionDirective = versionSpecifiers.TryGetValue(mod.name, out var version) && existing?.parsedVersion == version;
+                _ = versionSpecifiers.TryGetValue(mod.name, out var version);
 
-                if (modFound && higherVersionOrFolder && !existingMatchesVersionDirective) {
+                if (modFound && ShouldReplaceMod(existing, mod, version)) {
                     existing?.Dispose();
                     allMods[mod.name] = mod;
                 }
@@ -521,6 +520,25 @@ public static partial class FactorioDataSource {
 
     internal class ModList {
         public ModEntry[] mods { get; set; } = null!; // null-forgiving: Initialized by the Json reader.
+    }
+
+    internal static bool ShouldReplaceMod(ModInfo? existing, ModInfo candidate, Version? requestedVersion) {
+        if (existing == null) {
+            return true;
+        }
+
+        // A version from mod-list.json takes priority even if a newer archive was discovered first.
+        // When neither matches, retain the existing fallback to the newest installed version.
+        if (requestedVersion != null) {
+            bool candidateMatches = candidate.parsedVersion == requestedVersion;
+            bool existingMatches = existing.parsedVersion == requestedVersion;
+            if (candidateMatches != existingMatches) {
+                return candidateMatches;
+            }
+        }
+
+        return candidate.parsedVersion > existing.parsedVersion ||
+            (candidate.parsedVersion == existing.parsedVersion && existing.zipArchive != null && candidate.zipArchive == null);
     }
 
     internal partial class ModInfo : IDisposable {

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date:
     Features:
         - Allow planet selection for production tables, and complain if the selected recipe or entity can't be used there.
     Fixes:
+        - Honor mod-list.json version selections regardless of mod discovery order, preventing incompatible mod versions from being mixed.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.20.0
 Date: 17 July 2026


### PR DESCRIPTION
## Problem

YAFC can load a different mod version from the one selected in `mod-list.json` when several versions are installed. The result depends on filesystem discovery order: if version `2.1.1` is found before the requested `2.0.5`, the `higherVersionOrFolder` check prevents the requested version from replacing it. The existing version-directive check only protects a requested version that was selected already.

This caused a reproducible load failure with Bob's mods: YAFC mixed versions referring to `tungsten-ore` and `bob-tungsten-ore`, then failed while deserializing recipe ingredients with:

```text
data.raw does not contain an object named 'tungsten-ore' that can be loaded as a(n) Item (Parameter 'name')
```

## Change

Extract the replacement decision into a small, testable `ShouldReplaceMod` helper. Matching the requested version takes precedence over version ordering, so an older requested version can replace a newer candidate. If neither candidate matches the requested version, retain the existing newest-version fallback. For equal versions, prefer an unpacked folder over an archive, including when both match the requested version.

The refactor keeps selection policy in one place and leaves compatibility filtering and archive disposal in the existing loading loop. Add an unreleased changelog entry and regression tests for both discovery orders, unpinned and unavailable requested versions, and the folder/archive tie-break.

## Validation

- Reproduced the original `tungsten-ore` exception against an installed mod pack before the fix.
- Confirmed two regression cases fail with the original selection logic: discovering an older requested version second, and discovering its unpacked folder after its archive.
- All 25 parser tests pass with the fix (`dotnet test Yafc.Parser.Tests/Yafc.Parser.Tests.csproj --no-restore`).
- The same mod pack and existing project load successfully after the fix: 4,229 objects, `ErrorSeverity.None`. The project was loaded without saving changes.
- Published the macOS ARM64 Debug build successfully with .NET SDK 10.0.400.
- Verified formatting of the changed C# files and ran `git diff --check`.
